### PR TITLE
Add JwtTokenUtil test

### DIFF
--- a/JWT Authentication Normal/src/test/java/com/authentication/demo/JwtTokenUtilTest.java
+++ b/JWT Authentication Normal/src/test/java/com/authentication/demo/JwtTokenUtilTest.java
@@ -1,0 +1,30 @@
+package com.authentication.demo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.authentication.demo.config.JwtTokenUtil;
+
+public class JwtTokenUtilTest {
+
+    @Test
+    void testGenerateAndValidateToken() throws Exception {
+        JwtTokenUtil util = new JwtTokenUtil();
+
+        Field secretField = JwtTokenUtil.class.getDeclaredField("secret");
+        secretField.setAccessible(true);
+        secretField.set(util, "test_secret");
+
+        UserDetails userDetails = new User("dummy", "password", new ArrayList<>());
+        String token = util.generateToken(userDetails);
+
+        assertEquals("dummy", util.getUsernameFromToken(token));
+        assertTrue(util.validateToken(token, userDetails));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `JwtTokenUtil`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852a2b093608320ad4c673406503a40