### PR TITLE
Fix typo in GlobalExceptionHandler

### DIFF
--- a/JWT Authentication Normal/src/main/java/com/authentication/demo/exception/GlobalExceptionHandler.java
+++ b/JWT Authentication Normal/src/main/java/com/authentication/demo/exception/GlobalExceptionHandler.java
@@ -86,7 +86,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			HttpStatus status, WebRequest request) {
 		String message = ex.getMessage();
 		List<String> details = new ArrayList<>();
-		details.add("Request body is not redable");
+                details.add("Request body is not readable");
 
 		ApiError errors = new ApiError(message, LocalDateTime.now());
 		return ResponseEntity.status(status).body(errors);


### PR DESCRIPTION
## Summary
- fix misspelling of 'readable' in GlobalExceptionHandler

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852a313267883209e7b6593f3e4cfee