### PR TITLE
Fix typo in global exception handler

### DIFF
--- a/JWT Authentication Normal/src/main/java/com/authentication/demo/exception/GlobalExceptionHandler.java
+++ b/JWT Authentication Normal/src/main/java/com/authentication/demo/exception/GlobalExceptionHandler.java
@@ -86,7 +86,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			HttpStatus status, WebRequest request) {
 		String message = ex.getMessage();
 		List<String> details = new ArrayList<>();
-		details.add("Request body is not redable");
+		details.add("Request body is not readable");
 
 		ApiError errors = new ApiError(message, LocalDateTime.now());
 		return ResponseEntity.status(status).body(errors);


### PR DESCRIPTION
## Summary
- correct 'Request body is not redable' typo in `GlobalExceptionHandler`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6852a75ffc1483209b866628e51f395f